### PR TITLE
Stress- and stress sensitivity calculations flat_shell & quad_hexahedron elements

### DIFF
--- a/bso/structural_design/element/element.cpp
+++ b/bso/structural_design/element/element.cpp
@@ -141,6 +141,16 @@ namespace bso { namespace structural_design { namespace element {
 		throw std::runtime_error("cannot call getStressCenter() for this element type");
 	} // getStressCenter() gives error (standard) except for elements in which the function is overridden
 
+	Eigen::VectorXd element::getStressSensitivityTermAE(const unsigned long freeDOFs, const double& alpha /* 0*/) const
+	{
+		throw std::runtime_error("cannot call getStressSensitivityTermAE() for this element type");
+	} // getStressSensitivityTermAE() gives error (standard) except for elements in which the function is over-written
+
+	Eigen::VectorXd element::getStressSensitivity(Eigen::MatrixXd& Lamda, const double& penal /* 1*/, const double& beta /* 1.0 / sqrt(3)*/) const
+	{
+		throw std::runtime_error("cannot call getStressSensitivity() for this element type");
+	} // getStressSensitivity() gives error (standard) except for elements in which the function is over-written
+
 	const double& element::getEnergy(load_case lc, const std::string& type/*= ""*/) const
 	{ //
 		if (mEnergies.find(lc) != mEnergies.end())

--- a/bso/structural_design/element/element.cpp
+++ b/bso/structural_design/element/element.cpp
@@ -136,19 +136,28 @@ namespace bso { namespace structural_design { namespace element {
 		return this->getVolume();
 	} // getVolumeSensitivity()
 
-	double element::getStressCenter(const double& alpha /* 0*/, const double& beta /* 1.0 / sqrt(3)*/) const
+	double element::getStressAtCenter(const double& alpha /* 0*/, const double& beta /* 1.0 / sqrt(3)*/) const
 	{
-		throw std::runtime_error("cannot call getStressCenter() for this element type");
+		std::stringstream errorMessage;
+		errorMessage << "\nCannot call getStressAtCenter() for this element type\n"
+							<< "(bso/structural_design/element/element.cpp)" << std::endl;
+		throw std::runtime_error(errorMessage.str());
 	} // getStressCenter() gives error (standard) except for elements in which the function is overridden
 
 	Eigen::VectorXd element::getStressSensitivityTermAE(const unsigned long freeDOFs, const double& alpha /* 0*/) const
 	{
-		throw std::runtime_error("cannot call getStressSensitivityTermAE() for this element type");
+		std::stringstream errorMessage;
+		errorMessage << "\nCannot call getStressSensitivityTermAE() for this element type\n"
+							<< "(bso/structural_design/element/element.cpp)" << std::endl;
+		throw std::runtime_error(errorMessage.str());
 	} // getStressSensitivityTermAE() gives error (standard) except for elements in which the function is over-written
 
 	Eigen::VectorXd element::getStressSensitivity(Eigen::MatrixXd& Lamda, const double& penal /* 1*/, const double& beta /* 1.0 / sqrt(3)*/) const
 	{
-		throw std::runtime_error("cannot call getStressSensitivity() for this element type");
+		std::stringstream errorMessage;
+		errorMessage << "\nCannot call getStressSensitivity() for this element type\n"
+							<< "(bso/structural_design/element/element.cpp)" << std::endl;
+		throw std::runtime_error(errorMessage.str());
 	} // getStressSensitivity() gives error (standard) except for elements in which the function is over-written
 
 	const double& element::getEnergy(load_case lc, const std::string& type/*= ""*/) const

--- a/bso/structural_design/element/element.cpp
+++ b/bso/structural_design/element/element.cpp
@@ -136,6 +136,11 @@ namespace bso { namespace structural_design { namespace element {
 		return this->getVolume();
 	} // getVolumeSensitivity()
 
+	double element::getStressCenter(const double& alpha /* 0*/, const double& beta /* 1.0 / sqrt(3)*/) const
+	{
+		throw std::runtime_error("cannot call getStressCenter() for this element type");
+	} // getStressCenter() gives error (standard) except for elements in which the function is overridden
+
 	const double& element::getEnergy(load_case lc, const std::string& type/*= ""*/) const
 	{ //
 		if (mEnergies.find(lc) != mEnergies.end())

--- a/bso/structural_design/element/element.hpp
+++ b/bso/structural_design/element/element.hpp
@@ -62,7 +62,7 @@ namespace bso { namespace structural_design { namespace element {
 		virtual double getTotalEnergy() const;
 		virtual double getEnergySensitivity(const double& penal = 1) const;
 		virtual double getVolumeSensitivity() const;
-		virtual double getStressCenter(const double& alpha = 0, const double& beta = 1.0 / sqrt(3)) const;
+		virtual double getStressAtCenter(const double& alpha = 0, const double& beta = 1.0 / sqrt(3)) const;
 		virtual Eigen::VectorXd getStressSensitivityTermAE(const unsigned long freeDOFs, const double& alpha = 0) const;
 		virtual Eigen::VectorXd getStressSensitivity(Eigen::MatrixXd& Lamda, const double& penal = 1, const double& beta = 1.0 / sqrt(3)) const;
 		virtual bso::utilities::geometry::vertex getCenter() const = 0;

--- a/bso/structural_design/element/element.hpp
+++ b/bso/structural_design/element/element.hpp
@@ -63,6 +63,8 @@ namespace bso { namespace structural_design { namespace element {
 		virtual double getEnergySensitivity(const double& penal = 1) const;
 		virtual double getVolumeSensitivity() const;
 		virtual double getStressCenter(const double& alpha = 0, const double& beta = 1.0 / sqrt(3)) const;
+		virtual Eigen::VectorXd getStressSensitivityTermAE(const unsigned long freeDOFs, const double& alpha = 0) const;
+		virtual Eigen::VectorXd getStressSensitivity(Eigen::MatrixXd& Lamda, const double& penal = 1, const double& beta = 1.0 / sqrt(3)) const;
 		virtual bso::utilities::geometry::vertex getCenter() const = 0;
 		
 		const unsigned long& ID() const {return mID;}

--- a/bso/structural_design/element/element.hpp
+++ b/bso/structural_design/element/element.hpp
@@ -62,6 +62,7 @@ namespace bso { namespace structural_design { namespace element {
 		virtual double getTotalEnergy() const;
 		virtual double getEnergySensitivity(const double& penal = 1) const;
 		virtual double getVolumeSensitivity() const;
+		virtual double getStressCenter(const double& alpha = 0, const double& beta = 1.0 / sqrt(3)) const;
 		virtual bso::utilities::geometry::vertex getCenter() const = 0;
 		
 		const unsigned long& ID() const {return mID;}

--- a/bso/structural_design/element/flat_shell.cpp
+++ b/bso/structural_design/element/flat_shell.cpp
@@ -321,13 +321,11 @@ namespace bso { namespace structural_design { namespace element {
 		elementDisp24DOF.setZero(24);
 		elementDisp24DOF = mT * elementDisplacements;
 		melementDisp8DOF.setZero(8);
-		int counterDisp = 0;
 		for (int i = 0; i < 4; ++i) // for all nodes of this element
 		{
 			for (int j = 0; j < 2; ++j) // for the first two DOF's in local system (disp x & y)
 			{
-				melementDisp8DOF(counterDisp) = elementDisp24DOF(i*6 + j);
-				++counterDisp;
+				melementDisp8DOF(i*2 + j) = elementDisp24DOF(i*6 + j);
 			}
 		}
 		mBAv.setZero(3,8);
@@ -422,6 +420,8 @@ namespace bso { namespace structural_design { namespace element {
 	} // getStressCenter() - NOTE: if alpha & beta are not inserted in the function call, the Von Mises stress is obtained
 
 	Eigen::VectorXd flat_shell::getStressSensitivityTermAE(const unsigned long freeDOFs, const double& alpha /* 0*/) const
+	// Sensitivity calculation is based on the theory in:
+	// Luo, Y., & Kang, Z. (2012). Topology optimization of continuum structures with Drucker-Prager yield stress constraints. Computers & Structures, 90-91, pp. 65-75. https://doi.org/10.1016/j.compstruc.2011.10.008
 	{
 		Eigen::Vector3d w;
 		w << 1, 1, 0;
@@ -470,6 +470,8 @@ namespace bso { namespace structural_design { namespace element {
 	} // getStressSensitivityTermAE()
 
 	Eigen::VectorXd flat_shell::getStressSensitivity(Eigen::MatrixXd& Lamda, const double& penal /* 1*/, const double& beta /* 1.0 / sqrt(3)*/) const
+	// Sensitivity calculation is based on the theory in:
+	// Luo, Y., & Kang, Z. (2012). Topology optimization of continuum structures with Drucker-Prager yield stress constraints. Computers & Structures, 90-91, pp. 65-75. https://doi.org/10.1016/j.compstruc.2011.10.008
 	{
 		Eigen::VectorXd dKdxU = (-penal / beta) * pow(mDensity,penal - 1) * mE0K0U;
 		Eigen::MatrixXd lamdaloc;

--- a/bso/structural_design/element/flat_shell.cpp
+++ b/bso/structural_design/element/flat_shell.cpp
@@ -409,7 +409,7 @@ namespace bso { namespace structural_design { namespace element {
 		return bso::utilities::geometry::quadrilateral::getArea() * mThickness;
 	} // getVolume()
 	
-	double flat_shell::getStressCenter(const double& alpha /* 0*/, const double& beta /* 1.0 / sqrt(3)*/) const // NOTE: only in-plane stresses are considered (dKQ stresses are ignored) because of the application in topology optimization
+	double flat_shell::getStressAtCenter(const double& alpha /* 0*/, const double& beta /* 1.0 / sqrt(3)*/) const // NOTE: only in-plane stresses are considered (dKQ stresses are ignored) because of the application in topology optimization
 	{
 		double sx, sy, sxy, I1, J2D, DPStress;
 		sx = mStress(0);

--- a/bso/structural_design/element/flat_shell.hpp
+++ b/bso/structural_design/element/flat_shell.hpp
@@ -40,7 +40,7 @@ namespace bso { namespace structural_design { namespace element {
 		
 		double getProperty(std::string var) const;
 		double getVolume() const;
-		double getStressCenter(const double& alpha = 0, const double& beta = 1.0 / sqrt(3)) const;
+		double getStressAtCenter(const double& alpha = 0, const double& beta = 1.0 / sqrt(3)) const;
 		Eigen::VectorXd getStressSensitivityTermAE(const unsigned long freeDOFs, const double& alpha = 0) const;
 		Eigen::VectorXd getStressSensitivity(Eigen::MatrixXd& Lamda, const double& penal = 1, const double& beta = 1.0 / sqrt(3)) const;
 		bso::utilities::geometry::vertex getCenter() const;

--- a/bso/structural_design/element/flat_shell.hpp
+++ b/bso/structural_design/element/flat_shell.hpp
@@ -21,6 +21,7 @@ namespace bso { namespace structural_design { namespace element {
 		std::map<load_case, std::map<std::string, double>> mSeparatedEnergies;
 		Eigen::VectorXd melementDisp8DOF;
 		Eigen::Vector3d mStress;
+		Eigen::VectorXd mE0K0U;
 		
 		template<class CONTAINER>
 		void deriveStiffnessMatrix(CONTAINER& l);
@@ -40,6 +41,8 @@ namespace bso { namespace structural_design { namespace element {
 		double getProperty(std::string var) const;
 		double getVolume() const;
 		double getStressCenter(const double& alpha = 0, const double& beta = 1.0 / sqrt(3)) const;
+		Eigen::VectorXd getStressSensitivityTermAE(const unsigned long freeDOFs, const double& alpha = 0) const;
+		Eigen::VectorXd getStressSensitivity(Eigen::MatrixXd& Lamda, const double& penal = 1, const double& beta = 1.0 / sqrt(3)) const;
 		bso::utilities::geometry::vertex getCenter() const;
 		Eigen::VectorXd getStress() {return mStress;} // for unit test
 	};

--- a/bso/structural_design/element/flat_shell.hpp
+++ b/bso/structural_design/element/flat_shell.hpp
@@ -15,8 +15,12 @@ namespace bso { namespace structural_design { namespace element {
 		Eigen::MatrixXd mSMBending;
 		
 		Eigen::MatrixXd mT;
+		Eigen::MatrixXd mETermSolid; // 3x3 matrix with normal- and shear terms
+		Eigen::MatrixXd mB1, mB2, mB3, mB4, mBAv; // 3x8 (strain-displacement) matrices for in-plane behaviour
 		
 		std::map<load_case, std::map<std::string, double>> mSeparatedEnergies;
+		Eigen::VectorXd melementDisp8DOF;
+		Eigen::Vector3d mStress;
 		
 		template<class CONTAINER>
 		void deriveStiffnessMatrix(CONTAINER& l);
@@ -35,7 +39,9 @@ namespace bso { namespace structural_design { namespace element {
 		
 		double getProperty(std::string var) const;
 		double getVolume() const;
+		double getStressCenter(const double& alpha = 0, const double& beta = 1.0 / sqrt(3)) const;
 		bso::utilities::geometry::vertex getCenter() const;
+		Eigen::VectorXd getStress() {return mStress;} // for unit test
 	};
 	
 } // namespace element

--- a/bso/structural_design/element/quad_hexahedron.cpp
+++ b/bso/structural_design/element/quad_hexahedron.cpp
@@ -265,7 +265,7 @@ namespace bso { namespace structural_design { namespace element {
 		return bso::utilities::geometry::quad_hexahedron::getCenter();
 	} // getCenter()
 	
-	double quad_hexahedron::getStressCenter(const double& alpha /* 0*/, const double& beta /* 1.0 / sqrt(3)*/) const
+	double quad_hexahedron::getStressAtCenter(const double& alpha /* 0*/, const double& beta /* 1.0 / sqrt(3)*/) const
 	{
 		Eigen::MatrixXd V;
 		V.setZero(6,6);

--- a/bso/structural_design/element/quad_hexahedron.hpp
+++ b/bso/structural_design/element/quad_hexahedron.hpp
@@ -32,7 +32,7 @@ namespace bso { namespace structural_design { namespace element {
 		double getProperty(std::string var) const;
 		double getVolume() const;
 		bso::utilities::geometry::vertex getCenter() const;
-		double getStressCenter (const double& alpha = 0, const double& beta = 1.0 / sqrt(3)) const;
+		double getStressAtCenter (const double& alpha = 0, const double& beta = 1.0 / sqrt(3)) const;
 		Eigen::VectorXd getStressSensitivityTermAE(const unsigned long freeDOFs, const double& alpha = 0) const;
 		Eigen::VectorXd getStressSensitivity(Eigen::MatrixXd& Lamda, const double& penal = 1, const double& beta = 1.0 / sqrt(3)) const;
 		Eigen::Vector6d getStress() {return mStress;} // for unit test

--- a/bso/structural_design/element/quad_hexahedron.hpp
+++ b/bso/structural_design/element/quad_hexahedron.hpp
@@ -33,6 +33,8 @@ namespace bso { namespace structural_design { namespace element {
 		double getVolume() const;
 		bso::utilities::geometry::vertex getCenter() const;
 		double getStressCenter (const double& alpha = 0, const double& beta = 1.0 / sqrt(3)) const;
+		Eigen::VectorXd getStressSensitivityTermAE(const unsigned long freeDOFs, const double& alpha = 0) const;
+		Eigen::VectorXd getStressSensitivity(Eigen::MatrixXd& Lamda, const double& penal = 1, const double& beta = 1.0 / sqrt(3)) const;
 		Eigen::Vector6d getStress() {return mStress;} // for unit test
 	};
 	

--- a/bso/structural_design/element/quad_hexahedron.hpp
+++ b/bso/structural_design/element/quad_hexahedron.hpp
@@ -10,6 +10,10 @@ namespace bso { namespace structural_design { namespace element {
 		double mPoisson;
 		
 		Eigen::MatrixXd mT;
+		Eigen::MatrixXd mETermSolid; // 6x6 matrix with normal- and shear elasticity terms
+		Eigen::MatrixXd mBSum, mBAv; // sum and average of strain-displacement matrices in each integration point
+		Eigen::VectorXd mDispLoc;
+		Eigen::Vector6d mStress;
 
 		template<class CONTAINER>
 		void deriveStiffnessMatrix(CONTAINER& l);
@@ -22,10 +26,14 @@ namespace bso { namespace structural_design { namespace element {
 										std::initializer_list<node*>&& l, const double ERelativeLowerBound = 1e-6,
 										const double geomTol = 1e-3);
 		~quad_hexahedron();
-			
+
+		void computeResponse(load_case lc);
+
 		double getProperty(std::string var) const;
 		double getVolume() const;
 		bso::utilities::geometry::vertex getCenter() const;
+		double getStressCenter (const double& alpha = 0, const double& beta = 1.0 / sqrt(3)) const;
+		Eigen::Vector6d getStress() {return mStress;} // for unit test
 	};
 	
 } // namespace element

--- a/bso/structural_design/fea.cpp
+++ b/bso/structural_design/fea.cpp
@@ -296,12 +296,12 @@ namespace bso { namespace structural_design {
 	
 	Eigen::MatrixXd fea::solveAdjoint(Eigen::MatrixXd& ae) // for stress_based topopt
 	{
-		Eigen::MatrixXd Lamda;
+		Eigen::MatrixXd Lambda;
 		if (msolver == "SimplicialLLT")
 		{
 			try
 			{
-				Lamda = mLLTSolver.solve(ae);
+				Lambda = mLLTSolver.solve(ae);
 				if (mLLTSolver.info() != Eigen::Success)
 				{
 					throw std::runtime_error("Solver failed");
@@ -320,7 +320,7 @@ namespace bso { namespace structural_design {
 		{
 			try
 			{
-				Lamda = mLDLTSolver.solve(ae);
+				Lambda = mLDLTSolver.solve(ae);
 				if (mLDLTSolver.info() != Eigen::Success)
 				{
 					throw std::runtime_error("Solver failed");
@@ -342,7 +342,7 @@ namespace bso { namespace structural_design {
 										<< msolver << std::endl;
 			throw std::runtime_error(errorMessage.str());
 		}
-		return Lamda;
+		return Lambda;
 	} // solveAdjoint()
 
 	Eigen::VectorXd fea::getDisplacements(element::load_case lc) const

--- a/bso/structural_design/fea.cpp
+++ b/bso/structural_design/fea.cpp
@@ -8,9 +8,8 @@ namespace bso { namespace structural_design {
 	
 	void fea::simplicialLLT()
 	{
-		Eigen::SimplicialLLT<Eigen::SparseMatrix<double> > solver;
-		solver.compute(mGSM);
-		if (solver.info() != Eigen::Success)
+		mLLTSolver.compute(mGSM);
+		if (mLLTSolver.info() != Eigen::Success)
 		{
 			std::stringstream errorMessage;
 			errorMessage << "\nWhen solving an FEA system with SimplicialLLT,\n"
@@ -23,8 +22,8 @@ namespace bso { namespace structural_design {
 		{
 			try
 			{
-				mDisplacements[lc] = solver.solve(mLoads[lc]);
-				if (solver.info() != Eigen::Success)
+				mDisplacements[lc] = mLLTSolver.solve(mLoads[lc]);
+				if (mLLTSolver.info() != Eigen::Success)
 				{
 					throw std::runtime_error("Solver failed");
 				}
@@ -42,9 +41,8 @@ namespace bso { namespace structural_design {
 	
 	void fea::simplicialLDLT()
 	{
-		Eigen::SimplicialLDLT<Eigen::SparseMatrix<double> > solver;
-		solver.compute(mGSM);
-		if (solver.info() != Eigen::Success)
+		mLDLTSolver.compute(mGSM);
+		if (mLDLTSolver.info() != Eigen::Success)
 		{
 			std::stringstream errorMessage;
 			errorMessage << "\nWhen solving an FEA system with SimplicialLDLT,\n"
@@ -57,8 +55,8 @@ namespace bso { namespace structural_design {
 		{
 			try
 			{
-				mDisplacements[lc] = solver.solve(mLoads[lc]);
-				if (solver.info() != Eigen::Success)
+				mDisplacements[lc] = mLDLTSolver.solve(mLoads[lc]);
+				if (mLDLTSolver.info() != Eigen::Success)
 				{
 					throw std::runtime_error("Solver failed");
 				}
@@ -267,6 +265,7 @@ namespace bso { namespace structural_design {
 	
 	void fea::solve(std::string solver /*= "SimplicialLLT"*/)
 	{
+		msolver = solver;
 		// solve the system with the specified solver
 		this->clearResponse();
 		if (solver == "SimplicialLLT") this->simplicialLLT();
@@ -295,6 +294,57 @@ namespace bso { namespace structural_design {
 		}		
 	} // solve()
 	
+	Eigen::MatrixXd fea::solveAdjoint(Eigen::MatrixXd& ae) // for stress_based topopt
+	{
+		Eigen::MatrixXd Lamda;
+		if (msolver == "SimplicialLLT")
+		{
+			try
+			{
+				Lamda = mLLTSolver.solve(ae);
+				if (mLLTSolver.info() != Eigen::Success)
+				{
+					throw std::runtime_error("Solver failed");
+				}
+			}
+			catch (std::exception& e)
+			{
+				std::stringstream errorMessage;
+				errorMessage << "\nWhen solving an Adjoint system with SimplicialLLT \n"
+										<< "received the following error:\n" << e.what() << "\n"
+										<< "(bso/structural_design/fea.cpp)" << std::endl;
+				throw std::runtime_error(errorMessage.str());
+			}
+		}
+		else if (msolver == "SimplicialLDLT")
+		{
+			try
+			{
+				Lamda = mLDLTSolver.solve(ae);
+				if (mLDLTSolver.info() != Eigen::Success)
+				{
+					throw std::runtime_error("Solver failed");
+				}
+			}
+			catch (std::exception& e)
+			{
+				std::stringstream errorMessage;
+				errorMessage << "\nWhen solving an Adjoint system with SimplicialLDLT \n"
+										<< "received the following error:\n" << e.what() << "\n"
+										<< "(bso/structural_design/fea.cpp)" << std::endl;
+				throw std::runtime_error(errorMessage.str());
+			}
+		}
+		else
+		{
+			std::stringstream errorMessage;
+			errorMessage << "\nCould not solve Adjoint system with solver type: "
+										<< msolver << std::endl;
+			throw std::runtime_error(errorMessage.str());
+		}
+		return Lamda;
+	} // solveAdjoint()
+
 	Eigen::VectorXd fea::getDisplacements(element::load_case lc) const
 	{
 		auto dispSearch = mDisplacements.find(lc);

--- a/bso/structural_design/fea.hpp
+++ b/bso/structural_design/fea.hpp
@@ -48,7 +48,7 @@ namespace bso { namespace structural_design {
 		std::vector<element::node*>& getNodes() {return mNodes;}
 		const std::vector<element::element*>& getElements() const {return mElements;}
 		std::vector<element::element*>& getElements() {return mElements;}
-		const unsigned long getDOFCount() {return mDOFCount;}
+		const unsigned long& getDOFCount() const {return mDOFCount;}
 	};
 	
 } // namespace structural_design

--- a/bso/structural_design/fea.hpp
+++ b/bso/structural_design/fea.hpp
@@ -21,6 +21,10 @@ namespace bso { namespace structural_design {
 		Eigen::SparseMatrix<double> mGSM;
 		bool mSystemInitialized = false;
 		
+		std::string msolver;
+		Eigen::SimplicialLLT<Eigen::SparseMatrix<double> > mLLTSolver;
+		Eigen::SimplicialLDLT<Eigen::SparseMatrix<double> > mLDLTSolver;
+
 		// solvers
 		void simplicialLLT();
 		void simplicialLDLT();
@@ -37,12 +41,14 @@ namespace bso { namespace structural_design {
 		void clearResponse();
 		
 		void solve(std::string solver = "SimplicialLDLT");
+		Eigen::MatrixXd solveAdjoint(Eigen::MatrixXd& ae);
 		
 		Eigen::VectorXd getDisplacements(element::load_case lc) const;
 		const std::vector<element::node*>& getNodes() const {return mNodes;}
 		std::vector<element::node*>& getNodes() {return mNodes;}
 		const std::vector<element::element*>& getElements() const {return mElements;}
 		std::vector<element::element*>& getElements() {return mElements;}
+		const unsigned long getDOFCount() {return mDOFCount;}
 	};
 	
 } // namespace structural_design

--- a/unit_tests/structural_design/element/flat_shell_test.cpp
+++ b/unit_tests/structural_design/element/flat_shell_test.cpp
@@ -281,7 +281,7 @@ BOOST_AUTO_TEST_SUITE( sd_flat_shell_test )
 		Eigen::VectorXd Stress = fs1.getStress();
 		Eigen::VectorXd checkStress(3);
 		checkStress << 1e6,0,0; // sx = F/A, sy = sxy = 0
-		double VMStress = fs1.getStressCenter();
+		double VMStress = fs1.getStressAtCenter();
 		double checkVMStress = VMStress / 1e6 - 1;
 
 		BOOST_REQUIRE(Stress.isApprox(checkStress, 1e-3));
@@ -419,7 +419,7 @@ BOOST_AUTO_TEST_SUITE( sd_flat_shell_test )
 		Eigen::VectorXd Stress = fs1.getStress();
 		Eigen::VectorXd checkStress(3);
 		checkStress << 1.33333e6,0,0; // results from abaqus
-		double VMStress = fs1.getStressCenter();
+		double VMStress = fs1.getStressAtCenter();
 		double checkVMStress = VMStress / 1.33333e6 - 1;
 
 		BOOST_REQUIRE(Stress.isApprox(checkStress, 1e-3));
@@ -549,7 +549,7 @@ BOOST_AUTO_TEST_SUITE( sd_flat_shell_test )
 		Eigen::VectorXd checkStress1(3), checkStress2(3);
 		checkStress1 << 5.0e5,5.0e5,5.0e5; // results from abaqus
 		checkStress2 << 5.0e5,5.0e5,-5.0e5; // results from abaqus (negative shear)
-		double VMStress = fs1.getStressCenter();
+		double VMStress = fs1.getStressAtCenter();
 		double checkVMStress = VMStress / 1e6 - 1; // results from abaqus
 
 		BOOST_REQUIRE((Stress.isApprox(checkStress1, 1e-3) || Stress.isApprox(checkStress2,1e-3)));

--- a/unit_tests/structural_design/element/flat_shell_test.cpp
+++ b/unit_tests/structural_design/element/flat_shell_test.cpp
@@ -268,6 +268,24 @@ BOOST_AUTO_TEST_SUITE( sd_flat_shell_test )
 		checkDisplacements(9) = 20;
 		
 		BOOST_REQUIRE(displacements.isApprox(checkDisplacements, 1e-3));
+
+		bso::structural_design::component::load_case lc_test("test_case");
+		std::map<bso::structural_design::component::load_case, Eigen::VectorXd> displacementsnew;
+		displacementsnew[lc_test] = displacements;
+		n1.addDisplacements(displacementsnew);
+		n2.addDisplacements(displacementsnew);
+		n3.addDisplacements(displacementsnew);
+		n4.addDisplacements(displacementsnew);
+
+		fs1.computeResponse(lc_test);
+		Eigen::VectorXd Stress = fs1.getStress();
+		Eigen::VectorXd checkStress(3);
+		checkStress << 1e6,0,0; // sx = F/A, sy = sxy = 0
+		double VMStress = fs1.getStressCenter();
+		double checkVMStress = VMStress / 1e6 - 1;
+
+		BOOST_REQUIRE(Stress.isApprox(checkStress, 1e-3));
+		BOOST_REQUIRE(checkVMStress < 1e-3);
 	}
 	
 	BOOST_AUTO_TEST_CASE( benchmark_2 )
@@ -320,7 +338,23 @@ BOOST_AUTO_TEST_SUITE( sd_flat_shell_test )
 		checkDisplacements(12) = 36;
 		checkDisplacements(13) = -240;
 		checkDisplacements(15) = 36;	
+
 		BOOST_REQUIRE(displacements.isApprox(checkDisplacements, 1e-3));
+
+		bso::structural_design::component::load_case lc_test("test_case");
+		std::map<bso::structural_design::component::load_case, Eigen::VectorXd> displacementsnew;
+		displacementsnew[lc_test] = displacements;
+		n1.addDisplacements(displacementsnew);
+		n2.addDisplacements(displacementsnew);
+		n3.addDisplacements(displacementsnew);
+		n4.addDisplacements(displacementsnew);
+
+		fs1.computeResponse(lc_test);
+		Eigen::VectorXd Stress = fs1.getStress();
+		Eigen::VectorXd checkStress(3);
+		checkStress << 0,0,0; // out-of-plane loads do not cause in-plane stresses at the center plane of this element type (NOTE: stresses do occur at the top- and bottom of the flat shell element, but these are not considered (not calculated) in this toolbox) // Abaqus: sxx = +/- 6e6 (top and bottom)
+
+		BOOST_REQUIRE(Stress.isApprox(checkStress, 1e-3));
 	}
 	
 	BOOST_AUTO_TEST_CASE( benchmark_3 )
@@ -372,6 +406,24 @@ BOOST_AUTO_TEST_SUITE( sd_flat_shell_test )
 		checkDisplacements(13) = -8;
 				
 		BOOST_REQUIRE(displacements.isApprox(checkDisplacements, 1e-3));
+
+		bso::structural_design::component::load_case lc_test("test_case");
+		std::map<bso::structural_design::component::load_case, Eigen::VectorXd> displacementsnew;
+		displacementsnew[lc_test] = displacements;
+		n1.addDisplacements(displacementsnew);
+		n2.addDisplacements(displacementsnew);
+		n3.addDisplacements(displacementsnew);
+		n4.addDisplacements(displacementsnew);
+
+		fs1.computeResponse(lc_test);
+		Eigen::VectorXd Stress = fs1.getStress();
+		Eigen::VectorXd checkStress(3);
+		checkStress << 1.33333e6,0,0; // results from abaqus
+		double VMStress = fs1.getStressCenter();
+		double checkVMStress = VMStress / 1.33333e6 - 1;
+
+		BOOST_REQUIRE(Stress.isApprox(checkStress, 1e-3));
+		BOOST_REQUIRE(checkVMStress < 1e-3);
 	}
 	
 	BOOST_AUTO_TEST_CASE( benchmark_4 )
@@ -431,6 +483,77 @@ BOOST_AUTO_TEST_SUITE( sd_flat_shell_test )
 		// che.block<17,1>(0,1) << checkDisplacements;
 		// std::cout << che << std::endl;
 		BOOST_REQUIRE(displacements.isApprox(checkDisplacements, 1e-1));
+	}
+
+	BOOST_AUTO_TEST_CASE( benchmark_5 ) // Mixed loads
+	{
+		node n1({-1, 1,0},1);
+		node n2({ 1, 1,0},2);
+		node n3({ 1,-1,0},3);
+		node n4({-1,-1,0},4);
+		double E = 1e5;
+		double t = 1;
+		double v = 0.3;
+
+		n1.addConstraint(0);
+		n1.addConstraint(2);
+		n2.addConstraint(2);
+		n3.addConstraint(2);
+		n4.addConstraint(0);
+		n4.addConstraint(1);
+		n4.addConstraint(2);
+
+		flat_shell fs1(1,E,t,v,{&n1,&n2,&n3,&n4});
+
+		unsigned long DOFCount = 0;
+		n1.generateNFT(DOFCount);
+		n2.generateNFT(DOFCount);
+		n3.generateNFT(DOFCount);
+		n4.generateNFT(DOFCount);
+		fs1.generateEFT();
+
+		std::vector<triplet> triplets = fs1.getSMTriplets();
+		Eigen::SparseMatrix<double> GSM;
+		GSM.resize(DOFCount,DOFCount);
+		GSM.setFromTriplets(triplets.begin(), triplets.end());
+
+		Eigen::VectorXd loads;
+		loads.setZero(DOFCount);
+		loads(5) = 1e6;
+		loads(9) = 1e6;
+		Eigen::SimplicialLLT<Eigen::SparseMatrix<double> > solver;
+		solver.compute(GSM);
+		BOOST_REQUIRE(solver.info() == Eigen::Success);
+		Eigen::VectorXd displacements = solver.solve(loads);
+
+		Eigen::VectorXd checkDisplacements(DOFCount);
+		checkDisplacements.setZero(17);
+		checkDisplacements(0) = 7; // results from abaqus
+		checkDisplacements(4) = -33.4444;
+		checkDisplacements(5) = 73.4444;
+		checkDisplacements(9) = 47.4444;
+		checkDisplacements(10) = 66.4444;
+
+		BOOST_REQUIRE(displacements.isApprox(checkDisplacements, 1e-2));
+
+		bso::structural_design::component::load_case lc_test("test_case");
+		std::map<bso::structural_design::component::load_case, Eigen::VectorXd> displacementsnew;
+		displacementsnew[lc_test] = displacements;
+		n1.addDisplacements(displacementsnew);
+		n2.addDisplacements(displacementsnew);
+		n3.addDisplacements(displacementsnew);
+		n4.addDisplacements(displacementsnew);
+
+		fs1.computeResponse(lc_test);
+		Eigen::VectorXd Stress = fs1.getStress();
+		Eigen::VectorXd checkStress1(3), checkStress2(3);
+		checkStress1 << 5.0e5,5.0e5,5.0e5; // results from abaqus
+		checkStress2 << 5.0e5,5.0e5,-5.0e5; // results from abaqus (negative shear)
+		double VMStress = fs1.getStressCenter();
+		double checkVMStress = VMStress / 1e6 - 1; // results from abaqus
+
+		BOOST_REQUIRE((Stress.isApprox(checkStress1, 1e-3) || Stress.isApprox(checkStress2,1e-3)));
+		BOOST_REQUIRE(checkVMStress < 1e-3);
 	}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unit_tests/structural_design/element/quad_hexahedron_test.cpp
+++ b/unit_tests/structural_design/element/quad_hexahedron_test.cpp
@@ -347,7 +347,7 @@ BOOST_AUTO_TEST_SUITE( sd_quad_hexahedron_test )
 		Eigen::VectorXd Stress = qh1.getStress();
 		Eigen::VectorXd checkStress(6);
 		checkStress << 0,0,-1e5,0,0,0; // results from ansys (see graduation work Irma Bouw)
-		double VMStress = qh1.getStressCenter();
+		double VMStress = qh1.getStressAtCenter();
 		double checkVMStress = VMStress / 1e5 - 1;
 
 		BOOST_REQUIRE(Stress.isApprox(checkStress, 1e-3));
@@ -442,7 +442,7 @@ BOOST_AUTO_TEST_SUITE( sd_quad_hexahedron_test )
 		Eigen::VectorXd Stress = qh1.getStress();
 		Eigen::VectorXd checkStress(6);
 		checkStress << 0,0,0,-27.4627,0,400; // results from ansys (see graduation work Irma Bouw)
-		double VMStress = qh1.getStressCenter();
+		double VMStress = qh1.getStressAtCenter();
 		double checkVMStress = VMStress / 694.4513 - 1; // result from ansys
 
 		BOOST_REQUIRE(Stress.isApprox(checkStress, 1e-3));
@@ -537,7 +537,7 @@ BOOST_AUTO_TEST_SUITE( sd_quad_hexahedron_test )
 		Eigen::VectorXd Stress = qh1.getStress();
 		Eigen::VectorXd checkStress(6);
 		checkStress << 0,0,0,27.4627,0,0; // results from ansys (see graduation work Irma Bouw)
-		double VMStress = qh1.getStressCenter();
+		double VMStress = qh1.getStressAtCenter();
 		double checkVMStress = VMStress / 47.5668 - 1; // result from ansys
 
 		BOOST_REQUIRE(Stress.isApprox(checkStress, 1e-3));
@@ -632,7 +632,7 @@ BOOST_AUTO_TEST_SUITE( sd_quad_hexahedron_test )
 		Eigen::VectorXd Stress = qh1.getStress();
 		Eigen::VectorXd checkStress(6);
 		checkStress << -130.0,-130.0,0,0,0,0; // results from ansys (see graduation work Irma Bouw)
-		double VMStress = qh1.getStressCenter();
+		double VMStress = qh1.getStressAtCenter();
 		double checkVMStress = VMStress / 130.0000 - 1; // result from ansys
 
 		BOOST_REQUIRE(Stress.isApprox(checkStress, 1e-3));

--- a/unit_tests/structural_design/element/quad_hexahedron_test.cpp
+++ b/unit_tests/structural_design/element/quad_hexahedron_test.cpp
@@ -305,10 +305,10 @@ BOOST_AUTO_TEST_SUITE( sd_quad_hexahedron_test )
 
 		Eigen::VectorXd loads;
 		loads.setZero(DOFCount);
-		loads(7)  = -10; // node 5, force in z-direction
-		loads(10) = -10; // node 6, force in z-direction
-		loads(13) = -10; // node 7, force in z-direction
-		loads(16) = -10; // node 8, force in z-direction
+		loads(7)  = -1e5; // node 5, force in z-direction
+		loads(10) = -1e5; // node 6, force in z-direction
+		loads(13) = -1e5; // node 7, force in z-direction
+		loads(16) = -1e5; // node 8, force in z-direction
 		Eigen::SimplicialLLT<Eigen::SparseMatrix<double> > solver;
 		solver.compute(GSM);
 		BOOST_REQUIRE(solver.info() == Eigen::Success);
@@ -316,20 +316,42 @@ BOOST_AUTO_TEST_SUITE( sd_quad_hexahedron_test )
 
 		Eigen::VectorXd checkDisplacements;
 		checkDisplacements.setZero(DOFCount);
-		checkDisplacements(0)  = -3e-4; // results from abaqus and ansys
-		checkDisplacements(1)  = -3e-4; // see graduation work Diane Schoenmaker
-		checkDisplacements(2)  = -3e-4;
-		checkDisplacements(3)  = -3e-4;
-		checkDisplacements(5)  = -3e-4;
-		checkDisplacements(6)  = -3e-4;
-		checkDisplacements(7)  = -1e-3;
-		checkDisplacements(9)  = -3e-4;
-		checkDisplacements(10) = -1e-3;
-		checkDisplacements(13) = -1e-3;
-		checkDisplacements(14) = -3e-4;
-		checkDisplacements(16) = -1e-3;
+		checkDisplacements(0)  = -3; // results from abaqus and ansys
+		checkDisplacements(1)  = -3; // see graduation work Diane Schoenmaker
+		checkDisplacements(2)  = -3;
+		checkDisplacements(3)  = -3;
+		checkDisplacements(5)  = -3;
+		checkDisplacements(6)  = -3;
+		checkDisplacements(7)  = -10;
+		checkDisplacements(9)  = -3;
+		checkDisplacements(10) = -10;
+		checkDisplacements(13) = -10;
+		checkDisplacements(14) = -3;
+		checkDisplacements(16) = -10;
 
 		BOOST_REQUIRE(displacements.isApprox(checkDisplacements, 1e-3));
+
+		bso::structural_design::component::load_case lc_test("test_case");
+		std::map<bso::structural_design::component::load_case, Eigen::VectorXd> displacementsnew;
+		displacementsnew[lc_test] = displacements;
+		n1.addDisplacements(displacementsnew);
+		n2.addDisplacements(displacementsnew);
+		n3.addDisplacements(displacementsnew);
+		n4.addDisplacements(displacementsnew);
+		n5.addDisplacements(displacementsnew);
+		n6.addDisplacements(displacementsnew);
+		n7.addDisplacements(displacementsnew);
+		n8.addDisplacements(displacementsnew);
+
+		qh1.computeResponse(lc_test);
+		Eigen::VectorXd Stress = qh1.getStress();
+		Eigen::VectorXd checkStress(6);
+		checkStress << 0,0,-1e5,0,0,0; // results from ansys (see graduation work Irma Bouw)
+		double VMStress = qh1.getStressCenter();
+		double checkVMStress = VMStress / 1e5 - 1;
+
+		BOOST_REQUIRE(Stress.isApprox(checkStress, 1e-3));
+		BOOST_REQUIRE(checkVMStress < 1e-3);
 	}
 
 	BOOST_AUTO_TEST_CASE( benchmark_2 )  //shear test
@@ -403,6 +425,28 @@ BOOST_AUTO_TEST_SUITE( sd_quad_hexahedron_test )
 		checkDisplacements(11) =  3.76233e-3;
 
 		BOOST_REQUIRE(displacements.isApprox(checkDisplacements, 1e-3));
+
+		bso::structural_design::component::load_case lc_test("test_case");
+		std::map<bso::structural_design::component::load_case, Eigen::VectorXd> displacementsnew;
+		displacementsnew[lc_test] = displacements;
+		n1.addDisplacements(displacementsnew);
+		n2.addDisplacements(displacementsnew);
+		n3.addDisplacements(displacementsnew);
+		n4.addDisplacements(displacementsnew);
+		n5.addDisplacements(displacementsnew);
+		n6.addDisplacements(displacementsnew);
+		n7.addDisplacements(displacementsnew);
+		n8.addDisplacements(displacementsnew);
+
+		qh1.computeResponse(lc_test);
+		Eigen::VectorXd Stress = qh1.getStress();
+		Eigen::VectorXd checkStress(6);
+		checkStress << 0,0,0,-27.4627,0,400; // results from ansys (see graduation work Irma Bouw)
+		double VMStress = qh1.getStressCenter();
+		double checkVMStress = VMStress / 694.4513 - 1; // result from ansys
+
+		BOOST_REQUIRE(Stress.isApprox(checkStress, 1e-3));
+		BOOST_REQUIRE(checkVMStress < 1e-3);
 	}
 
 	BOOST_AUTO_TEST_CASE( benchmark_3 )    //Bending test
@@ -476,6 +520,28 @@ BOOST_AUTO_TEST_SUITE( sd_quad_hexahedron_test )
 		checkDisplacements(11) = -3.76233e-3;
 
 		BOOST_REQUIRE(displacements.isApprox(checkDisplacements, 1e-3));
+
+		bso::structural_design::component::load_case lc_test("test_case");
+		std::map<bso::structural_design::component::load_case, Eigen::VectorXd> displacementsnew;
+		displacementsnew[lc_test] = displacements;
+		n1.addDisplacements(displacementsnew);
+		n2.addDisplacements(displacementsnew);
+		n3.addDisplacements(displacementsnew);
+		n4.addDisplacements(displacementsnew);
+		n5.addDisplacements(displacementsnew);
+		n6.addDisplacements(displacementsnew);
+		n7.addDisplacements(displacementsnew);
+		n8.addDisplacements(displacementsnew);
+
+		qh1.computeResponse(lc_test);
+		Eigen::VectorXd Stress = qh1.getStress();
+		Eigen::VectorXd checkStress(6);
+		checkStress << 0,0,0,27.4627,0,0; // results from ansys (see graduation work Irma Bouw)
+		double VMStress = qh1.getStressCenter();
+		double checkVMStress = VMStress / 47.5668 - 1; // result from ansys
+
+		BOOST_REQUIRE(Stress.isApprox(checkStress, 1e-3));
+		BOOST_REQUIRE(checkVMStress < 1e-3);
 	}
 
 	BOOST_AUTO_TEST_CASE( benchmark_4 )   // Torsion test
@@ -525,9 +591,9 @@ BOOST_AUTO_TEST_SUITE( sd_quad_hexahedron_test )
 		Eigen::VectorXd loads;
 		loads.setZero(DOFCount);
 		loads(0)  = 100;  // node 5, force in x-direction
-		loads(4)  = 100;  // node 6, force in x-direction
+		loads(4)  = 100;  // node 6, force in y-direction
 		loads(6)  = -100; // node 7, force in x-direction
-		loads(10) = -100; // node 8, force in x-direction
+		loads(10) = -100; // node 8, force in y-direction
 		Eigen::SimplicialLLT<Eigen::SparseMatrix<double> > solver;
 		solver.compute(GSM);
 		BOOST_REQUIRE(solver.info() == Eigen::Success);
@@ -549,6 +615,28 @@ BOOST_AUTO_TEST_SUITE( sd_quad_hexahedron_test )
 		checkDisplacements(11) =  3.700e-4;
 
 		BOOST_REQUIRE(displacements.isApprox(checkDisplacements, 1e-3));
+
+		bso::structural_design::component::load_case lc_test("test_case");
+		std::map<bso::structural_design::component::load_case, Eigen::VectorXd> displacementsnew;
+		displacementsnew[lc_test] = displacements;
+		n1.addDisplacements(displacementsnew);
+		n2.addDisplacements(displacementsnew);
+		n3.addDisplacements(displacementsnew);
+		n4.addDisplacements(displacementsnew);
+		n5.addDisplacements(displacementsnew);
+		n6.addDisplacements(displacementsnew);
+		n7.addDisplacements(displacementsnew);
+		n8.addDisplacements(displacementsnew);
+
+		qh1.computeResponse(lc_test);
+		Eigen::VectorXd Stress = qh1.getStress();
+		Eigen::VectorXd checkStress(6);
+		checkStress << -130.0,-130.0,0,0,0,0; // results from ansys (see graduation work Irma Bouw)
+		double VMStress = qh1.getStressCenter();
+		double checkVMStress = VMStress / 130.0000 - 1; // result from ansys
+
+		BOOST_REQUIRE(Stress.isApprox(checkStress, 1e-3));
+		BOOST_REQUIRE(checkVMStress < 1e-3);
 
 	}
 


### PR DESCRIPTION
The first four commits enable the calculation of the average stress at the center of flat_shell or quad_hexahedron elements. The Von Mises or Drucker-Prager equivalent stress values at the center of the element can be obtained by calling "getStressCenter". Furthermore, the unit_tests for flat_shell and quad_hexahedron elements have been extended such that these include a check on the obtained stress values. These unit tests were verified using Abaqus and Ansys.

The last four commits enable the stress sensitivity calculation of the average stress at the center of flat_shell or quad_hexahedron elements. To calculate the stress sensitivity of flat_shell or quad_hexahedron elements, first call "getStressSensitivityTermAE" for each element, which returns an adjoint load vector a(e) for each element e. Subsequently, merge these adjoint load vectors in an Eigen::MatrixXd, and solve the adjoint system of equations: K*Lamda(e) = a(e) to find the Lamda vectors. Finally, call "getStressSensitivity" for each element (e), which takes the matrix with all Lamda's as one of its inputs, to get the sensitivity of all stress constraints to the density of element (e).